### PR TITLE
Fix list categories test bug

### DIFF
--- a/test/integration/list_categories_test.rb
+++ b/test/integration/list_categories_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
-class CreateCategoriesTest < ActionDispatch::IntegrationTest
+class ListCategoriesTest < ActionDispatch::IntegrationTest
 
   def setup
-    @category = Category.create(name: "books")
+    @category = Category.create(name: "sports")
     @category2 = Category.create(name: "programming")
   end
 


### PR DESCRIPTION
Bug : 

Finished in 0.428097s, 25.6951 runs/s, 42.0465 assertions/s.

  1) Failure:
CreateCategoriesTest#test_get_new_category_form_and_create_category [/home/nithin/MyExperimentsWithRails/alpha-blog/test/integration/create_categories_test.rb:8]:
"Category.count" didn't change by 1.
Expected: 3
  Actual: 2

11 runs, 18 assertions, 1 failures, 0 errors, 0 skips

Resolution : 

Fixed the above bug by changing the class name appropriately.
